### PR TITLE
Updated Github Mark in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 
 <img src="http://axure.guru/wp-content/uploads/2017/12/faLogoFull.jpg" border="0" width="180px" height="100px">
 <img src="http://daynin.github.io/clojurescript-presentation/img/react-logo.png" border="0" width="100px" height="100px">
-<img src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" border="0" width="100px" height="100px"></center>
+<img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" border="0" width="100px" height="100px"></center>
 </p>
 
 <h1 align="center">Made with :heart: By Piyush Mehta for :octocat: </h1>


### PR DESCRIPTION
The CDN has changed for GitHub mark so the image was corrupted.

This year started hacktoberfest with inspiration that you have given to me at DSC summit.